### PR TITLE
Always pull newest version of parent image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker build -t ipunkt/libreoffice-headless:latest .
+docker build --pull -t ipunkt/libreoffice-headless:latest .


### PR DESCRIPTION
This makes sure that every time the parent Ubuntu image is updated, the newest version will be downloaded, rather than using the local version.